### PR TITLE
Add the ldapExternalSaslBind function for trivial (no control, no interaction) external SASL binds

### DIFF
--- a/LDAP.cabal
+++ b/LDAP.cabal
@@ -21,7 +21,7 @@ Flag buildtests
   default: False
 
 Library
-  -- C-Sources: glue/glue.c
+  C-Sources: sasl_external.c
   Exposed-Modules: LDAP,
    LDAP.Types,
    LDAP.Init,

--- a/LDAP/Init.hsc
+++ b/LDAP/Init.hsc
@@ -23,7 +23,8 @@ Written by John Goerzen, jgoerzen\@complete.org
 module LDAP.Init(ldapOpen,
                  ldapInit,
                  ldapInitialize,
-                 ldapSimpleBind)
+                 ldapSimpleBind,
+                 ldapExternalSaslBind)
 where
 
 import Foreign.Ptr
@@ -106,6 +107,15 @@ ldapSimpleBind ld dn passwd =
            return ()
                          )))
 
+{- | Bind with SASL external mechanism. -}
+ldapExternalSaslBind :: LDAP -- ^ LDAP Object
+                     -> IO ()
+ldapExternalSaslBind ld =
+    withLDAPPtr ld (\ptr ->
+        do checkLE "ldapExternalSaslBind" ld (sasl_trivial_external ptr)
+           return ()
+      )
+
 foreign import ccall unsafe "ldap.h ldap_init"
   cldap_init :: CString -> CInt -> IO LDAPPtr
 
@@ -118,6 +128,9 @@ foreign import ccall unsafe "ldap.h ldap_initialize"
 
 foreign import ccall unsafe "ldap.h ldap_simple_bind_s"
   ldap_simple_bind_s :: LDAPPtr -> CString -> CString -> IO LDAPInt
+
+foreign import ccall unsafe
+  sasl_trivial_external :: LDAPPtr -> IO LDAPInt
 
 foreign import ccall unsafe "ldap.h ldap_set_option"
   ldap_set_option :: LDAPPtr -> LDAPInt -> Ptr () -> IO LDAPInt

--- a/sasl_external.c
+++ b/sasl_external.c
@@ -1,0 +1,18 @@
+#include <ldap.h>
+
+static int sasl_trivial_interact (LDAP *ld, unsigned flags, void *defaults,
+                                  void *sasl_interact)
+{
+    (void)ld;
+    (void)flags;
+    (void)defaults;
+    (void)sasl_interact;
+    return LDAP_SUCCESS;
+}
+
+int sasl_trivial_external (LDAP *ld)
+{
+    return ldap_sasl_interactive_bind_s (ld, NULL, "EXTERNAL", NULL, NULL,
+                                         LDAP_SASL_QUIET,
+                                         sasl_trivial_interact, NULL);
+}


### PR DESCRIPTION
Hi,
I'm starting to use this functionality, would you please consider including it? This could be done in a more general fashion, but that's out of my scope right now.
