### PR TITLE
Updating tests to work with newer cabal best-practices

### DIFF
--- a/LDAP.cabal
+++ b/LDAP.cabal
@@ -1,3 +1,5 @@
+cabal-version: >=1.8
+
 Name: LDAP
 Version: 0.6.10
 License: BSD3
@@ -14,7 +16,6 @@ license-file: COPYRIGHT
 extra-source-files: COPYING
 
 Build-Type: Simple
-Cabal-Version: >=1.2.3
 
 Flag buildtests
   description: Build the executable to run unit tests
@@ -39,6 +40,7 @@ Library
 
   Extra-Libraries: ldap, lber
 
+
   GHC-Options: -O2
   -- CC-Options: -Iglue
   if os(openbsd)
@@ -48,12 +50,27 @@ Library
   Extensions: ForeignFunctionInterface, TypeSynonymInstances,
               EmptyDataDecls, ScopedTypeVariables, CPP
 
+Test-Suite test-ldap
+  type: exitcode-stdio-1.0
+  main-is: runtests.hs
+  Extra-Libraries: ldap, lber
+  build-depends: base >= 4 && < 5,
+                 LDAP,
+                 HUnit
+  if os(openbsd)
+    CC-Options: -DLDAP_X_PROXY_AUTHZ_FAILURE=LDAP_PROXY_AUTHZ_FAILURE
+  else
+    CC-Options: -DLDAP_DEPRECATED=1
+  GHC-Options: -O2
+  Extensions: ForeignFunctionInterface, TypeSynonymInstances,
+              EmptyDataDecls, ScopedTypeVariables, CPP
+  hs-source-dirs: testsrc, .
+
 Executable runtests
   if flag(buildtests)
     Buildable: True
   else
     Buildable: False
-  Extra-Libraries: ldap, lber
   Main-Is: runtests.hs
   if os(openbsd)
     CC-Options: -DLDAP_X_PROXY_AUTHZ_FAILURE=LDAP_PROXY_AUTHZ_FAILURE

--- a/testsrc/Tests.hs
+++ b/testsrc/Tests.hs
@@ -13,11 +13,7 @@ testSearchNoAttrs = TestCase $ do
     -- A sample public LDAP server
     ldap <- ldapInitialize "ldap://scripts.mit.edu/"
     r <- ldapSearch ldap (Just "ou=People,dc=scripts,dc=mit,dc=edu") LdapScopeOnelevel Nothing LDAPNoAttrs True
-    evaluate (length (show r)) -- poor mans rnf
-    return ()
+    assertBool "Search does not return results" (length r > 0)
 
 tests = TestList [TestLabel "testSearchNoAttrs" testSearchNoAttrs
                  ]
-
-
-


### PR DESCRIPTION
Running with the flag buildtests on the latest cabal resulted in a build error. 
I've left it in for backwards compatibility (but the upped cabal-version may prove problematic toward that end).

Also slightly modified sole(!) test case. I feel that assertBool is more clear.