### PR TITLE
Long running FFI commands should be marked 'safe'.

### DIFF
--- a/LDAP/Init.hsc
+++ b/LDAP/Init.hsc
@@ -110,13 +110,13 @@ foreign import ccall unsafe "ldap.h ldap_init"
   cldap_init :: CString -> CInt -> IO LDAPPtr
 
 
-foreign import ccall unsafe "ldap.h ldap_open"
+foreign import ccall safe "ldap.h ldap_open"
   cldap_open :: CString -> CInt -> IO LDAPPtr
 
 foreign import ccall unsafe "ldap.h ldap_initialize"
   ldap_initialize :: Ptr LDAPPtr -> CString -> IO LDAPInt
 
-foreign import ccall unsafe "ldap.h ldap_simple_bind_s"
+foreign import ccall safe "ldap.h ldap_simple_bind_s"
   ldap_simple_bind_s :: LDAPPtr -> CString -> CString -> IO LDAPInt
 
 foreign import ccall unsafe "ldap.h ldap_set_option"

--- a/LDAP/Modify.hsc
+++ b/LDAP/Modify.hsc
@@ -122,11 +122,11 @@ freeCLDAPMod ptr =
 withCLDAPModArr0 :: [LDAPMod] -> (Ptr (Ptr CLDAPMod) -> IO a) -> IO a
 withCLDAPModArr0 = withAnyArr0 newCLDAPMod freeCLDAPMod
 
-foreign import ccall unsafe "ldap.h ldap_modify_s"
+foreign import ccall safe "ldap.h ldap_modify_s"
   ldap_modify_s :: LDAPPtr -> CString -> Ptr (Ptr CLDAPMod) -> IO LDAPInt
 
-foreign import ccall unsafe "ldap.h ldap_delete_s"
+foreign import ccall safe "ldap.h ldap_delete_s"
   ldap_delete_s :: LDAPPtr -> CString -> IO LDAPInt
 
-foreign import ccall unsafe "ldap.h ldap_add_s"
+foreign import ccall safe "ldap.h ldap_add_s"
   ldap_add_s :: LDAPPtr -> CString -> Ptr (Ptr CLDAPMod) -> IO LDAPInt

--- a/LDAP/Result.hsc
+++ b/LDAP/Result.hsc
@@ -54,7 +54,7 @@ fromldmptr caller action =
           then fail (caller ++ ": got null LDAPMessage pointer")
           else newForeignPtr ldap_msgfree_call ptr
 
-foreign import ccall unsafe "ldap.h ldap_result"
+foreign import ccall safe "ldap.h ldap_result"
   ldap_result :: LDAPPtr -> LDAPInt -> LDAPInt -> Ptr () -> Ptr (Ptr CLDAPMessage) -> IO LDAPInt
 
 foreign import ccall unsafe "ldap.h &ldap_msgfree"

--- a/LDAP/Search.hsc
+++ b/LDAP/Search.hsc
@@ -153,7 +153,7 @@ foreign import ccall unsafe "ldap.h ldap_get_values_len"
 foreign import ccall unsafe "ldap.h ldap_value_free_len"
   ldap_value_free_len :: Ptr (Ptr Berval) -> IO ()
 
-foreign import ccall unsafe "ldap.h ldap_search"
+foreign import ccall safe "ldap.h ldap_search"
   ldap_search :: LDAPPtr -> CString -> LDAPInt -> CString -> Ptr CString ->
                  LDAPInt -> IO LDAPInt
 


### PR DESCRIPTION
If they are marked "unsafe", they stop the whole runtime. LDAP calls can sometimes take quite a long time.