### PR TITLE
Add the ldapExternalSaslBind function

### DIFF
--- a/LDAP.cabal
+++ b/LDAP.cabal
@@ -13,7 +13,9 @@ Synopsis: Haskell binding for C LDAP API
 Description: This package provides LDAP interface code for Haskell programs,
  binding to the C LDAP API.
 license-file: COPYRIGHT
-extra-source-files: COPYING
+extra-source-files:
+ COPYING
+ sasl_external.h
 
 Build-Type: Simple
 

--- a/LDAP.cabal
+++ b/LDAP.cabal
@@ -22,7 +22,7 @@ Flag buildtests
   default: False
 
 Library
-  -- C-Sources: glue/glue.c
+  C-Sources: sasl_external.c
   Exposed-Modules: LDAP,
    LDAP.Types,
    LDAP.Init,

--- a/LDAP/Init.hsc
+++ b/LDAP/Init.hsc
@@ -131,7 +131,7 @@ foreign import ccall unsafe "ldap.h ldap_initialize"
 foreign import ccall safe "ldap.h ldap_simple_bind_s"
   ldap_simple_bind_s :: LDAPPtr -> CString -> CString -> IO LDAPInt
 
-foreign import ccall safe
+foreign import ccall safe "sasl_external.h external_sasl_bind"
   external_sasl_bind :: LDAPPtr -> CString -> Int -> IO LDAPInt
 
 foreign import ccall unsafe "ldap.h ldap_set_option"

--- a/sasl_external.c
+++ b/sasl_external.c
@@ -1,0 +1,37 @@
+#include <ldap.h>
+#include <sasl/sasl.h>
+
+struct external_defaults {
+  const char *authzPtr;
+  int authzLen;
+};
+
+static int external_interact (LDAP *ld, unsigned flags, void *defaults, void *sasl_interact)
+{
+  (void)ld;
+  (void)flags;
+  struct external_defaults *defs = defaults;
+  sasl_interact_t *interact;
+
+  for (interact = sasl_interact; interact->id != SASL_CB_LIST_END; interact++) {
+    switch (interact->id) {
+    case SASL_CB_USER:
+      if (defs->authzLen) {
+        interact->result = defs->authzPtr;
+        interact->len = defs->authzLen;
+      }
+      break;
+    /* RFC 4422 (SASL) doesn't allow any other callbacks for EXTERNAL */
+    }
+  }
+  return LDAP_SUCCESS;
+}
+
+int external_sasl_bind (LDAP *ld, const char *authz, int len)
+{
+  struct external_defaults defaults = { authzPtr: authz, authzLen: len };
+
+  return ldap_sasl_interactive_bind_s (ld, NULL, "EXTERNAL", NULL, NULL,
+                                       LDAP_SASL_QUIET,
+                                       external_interact, &defaults);
+}

--- a/sasl_external.c
+++ b/sasl_external.c
@@ -1,6 +1,8 @@
 #include <ldap.h>
 #include <sasl/sasl.h>
 
+#include "sasl_external.h"
+
 struct external_defaults {
   const char *authzPtr;
   int authzLen;

--- a/sasl_external.h
+++ b/sasl_external.h
@@ -1,0 +1,3 @@
+#include <ldap.h>
+
+int external_sasl_bind (LDAP *ld, const char *authz, int len);


### PR DESCRIPTION
The implementation requires Cyrus SASL 2, just like OpenLDAP does.

This includes support for setting the authorization identity.
Because this package as a whole does not support LDAP controls (we really should do something about that another time), I think there's no need to represent this shortcoming in the function name. Other than that, this `ldapExternalSaslBind` is as general as possible, according to my current (very fresh) knowledge.