### PR TITLE
Expose page control related functions

### DIFF
--- a/LDAP.cabal
+++ b/LDAP.cabal
@@ -33,10 +33,11 @@ Library
    LDAP.Data,
    LDAP.Exceptions,
    LDAP.Search,
-   LDAP.Modify
+   LDAP.Result,
+   LDAP.Modify,
+   LDAP.Control
   Other-Modules: LDAP.Utils,
-   LDAP.TypesLL,
-   LDAP.Result
+   LDAP.TypesLL
   Build-Depends: base
 
   build-depends: base >= 4 && <5

--- a/LDAP.hs
+++ b/LDAP.hs
@@ -32,6 +32,10 @@ module LDAP (-- * Basic Types
              module LDAP.Init,
              -- * Searching
              module LDAP.Search,
+             -- * Results
+             module LDAP.Result,
+             -- * Control
+             module LDAP.Control,
              -- * Adding, Deleting, and Altering
              module LDAP.Modify,
              -- * Error Handling
@@ -48,5 +52,7 @@ import LDAP.Init
 import LDAP.Data
 import LDAP.Constants
 import LDAP.Search hiding (LDAPScope(..))
+import LDAP.Result (LDAPMessage)
 import LDAP.Modify hiding (LDAPModOp(..))
+import LDAP.Control
 

--- a/LDAP/Control.hsc
+++ b/LDAP/Control.hsc
@@ -1,0 +1,64 @@
+module LDAP.Control (LDAPControl,
+                     CLDAPControl,
+                     LDAPCookie,
+                     ldapCreatePageControl,
+                     ldapParsePageControl,
+                     ldap_control_free
+                    )
+where
+
+#include <ldap.h>
+
+import LDAP.Utils
+import LDAP.Types
+import LDAP.TypesLL
+import Foreign
+import Foreign.C.Types
+
+data CLDAPControl
+type LDAPControl = ForeignPtr CLDAPControl
+
+type LDAPCookie = ForeignPtr Berval
+
+ldapCreatePageControl :: LDAP             -- ^ LDAP connection object
+                      -> Int              -- ^ Page Size
+                      -> Maybe LDAPCookie -- ^ Cookie
+                      -> Bool             -- ^ Specifies the criticality of paged results on the search
+                      -> IO (LDAPControl)
+ldapCreatePageControl ld count cookie critical =
+    withLDAPPtr ld $ \cld ->
+    maybeWith withForeignPtr cookie $ \ccookie ->
+    alloca $ \ccontrol -> do
+        let ccount = fromIntegral count
+            ccritical = fromBool critical
+        checkLE "ldapCreatePageControl" ld $
+            ldap_create_page_control cld ccount ccookie ccritical ccontrol
+        newForeignPtr ldap_control_free =<< peek ccontrol
+
+ldapParsePageControl :: LDAP -> [LDAPControl] -> IO (Maybe LDAPCookie)
+ldapParsePageControl ld ctrls =
+    withLDAPPtr ld $ \cld ->
+    withArrayOfForeign0 nullPtr ctrls $ \cctrls ->
+    alloca $ \ccookie -> do
+        checkLE "ldapParsePageControl" ld $
+            ldap_parse_page_control cld cctrls nullPtr ccookie
+        cookie <- newForeignPtr ldap_memfree_call =<< peek ccookie
+        withForeignPtr cookie $ \pcookie -> do
+            str <- bv2str pcookie
+            pure $ case str of
+                       "" -> Nothing
+                       _ -> Just cookie
+
+foreign import ccall safe "ldap.h ldap_create_page_control"
+  ldap_create_page_control :: LDAPPtr -> BERInt -> Ptr Berval -> LDAPInt ->
+                              Ptr (Ptr CLDAPControl) -> IO LDAPInt
+
+foreign import ccall safe "ldap.h &ldap_control_free"
+  ldap_control_free :: FunPtr (Ptr CLDAPControl -> IO ())
+
+foreign import ccall safe "ldap.h ldap_parse_page_control"
+  ldap_parse_page_control :: LDAPPtr -> Ptr (Ptr CLDAPControl) -> Ptr (BERInt) ->
+                             Ptr (Ptr Berval) -> IO LDAPInt
+
+foreign import ccall unsafe "ldap.h &ldap_memfree"
+  ldap_memfree_call :: FunPtr (Ptr Berval -> IO ())

--- a/LDAP/Result.hsc
+++ b/LDAP/Result.hsc
@@ -21,7 +21,7 @@ Written by John Goerzen, jgoerzen\@complete.org
 -}
 
 module LDAP.Result (LDAPMessage, CLDAPMessage,
-                    ldap_1result
+                    ldap_1result, ldap_msgfree_call
                    ) where
 
 import LDAP.Utils

--- a/LDAP/Search.hsc
+++ b/LDAP/Search.hsc
@@ -128,7 +128,7 @@ ldapSearchExt ld base scope filters attrs attrsonly serverctrls clientctrls time
         checkLE "ldapSearchExt" ld $
             ldap_search_ext_s cld cbase cscope cfilters cattrs cattrsonly
                 cserverctrls cclientctrls ctimeout csizelimit cmsg
-        newForeignPtr ldap_msgfree_call =<< peek cmsg
+        newForeignPtr ldap_msgfree_call =<< checkNULL "ldapSearchExt" (peek cmsg)
 
 ldapParseResult :: LDAP -> LDAPMessage -> IO ([LDAPEntry], [LDAPControl])
 ldapParseResult ld msg =

--- a/LDAP/Utils.hsc
+++ b/LDAP/Utils.hsc
@@ -29,7 +29,7 @@ module LDAP.Utils(checkLE, checkLEe, checkLEn1,
                   withLDAPPtr, maybeWithLDAPPtr, withMString,
                   withCStringArr0, ldap_memfree,
                   bv2str, newBerval, freeHSBerval,
-                  withAnyArr0) where
+                  withAnyArr0, withArrayOfForeign0) where
 import Foreign.Ptr
 import LDAP.Constants
 import LDAP.Exceptions
@@ -160,6 +160,10 @@ withAnyArr0 input2ptract freeact inp action =
     bracket (mapM input2ptract inp)
             (\clist -> mapM_ freeact clist)
             (\clist -> withArray0 nullPtr clist action)
+
+withArrayOfForeign0 :: Ptr a -> [ForeignPtr a] -> (Ptr (Ptr a) -> IO b) -> IO b
+withArrayOfForeign0 marker val ppa =
+    withMany withForeignPtr val $ \cval -> withArray0 marker cval (($) ppa)
 
 withBervalArr0 :: [String] -> (Ptr (Ptr Berval) -> IO a) -> IO a
 withBervalArr0 = withAnyArr0 newBerval freeHSBerval


### PR DESCRIPTION
This PR expose the functions needed to page the results of a query. 

Basically, the introduced Haskell functions work just like their C counterpart.

Documentation about theses functions can be found [here](https://www.ibm.com/docs/en/i/7.3?topic=ssw_ibm_i_73/apis/ldap_paged_results.htm)